### PR TITLE
Fix packing of PKCS#11 structures

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 #include "pkcs11-env.h"
-#include <pkcs11.h>
 
 #include <set>
 #include <map>

--- a/makefile
+++ b/makefile
@@ -12,6 +12,11 @@ dump_opencryptoki: pkcs11test
 dump_chaps: pkcs11test
 	./pkcs11test -m libchaps.so.0 -l /usr/lib --gtest_filter=*.Enumerate* -X -v
 
+# Define STRICT_P11 somewhere to force 1-byte alignment on P11 structures
+ifneq (, $(STRICT_P11))
+    CXXFLAGS+=-DSTRICT_P11
+endif
+
 GTEST_DIR=gtest-1.6.0
 GTEST_INC=-isystem $(GTEST_DIR)/include
 CXXFLAGS+=-Ithird_party/pkcs11  $(GTEST_INC) -g -std=c++0x -Wall

--- a/pkcs11-describe.h
+++ b/pkcs11-describe.h
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 #include "pkcs11-env.h"
-#include <pkcs11.h>
 
 #include <string>
 

--- a/pkcs11-env.h
+++ b/pkcs11-env.h
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 /* From 2.1 of [PKCS11-base-v2.40]: Cryptoki structures SHALL be packed with 1-byte alignment. */
-#pragma pack(push, cryptoki, 1)
+#pragma pack(push, 1)
 
 /* The following definitions need to be provided to the preprocessor before the PKCS#11 header file can be included */
 #define CK_PTR *
@@ -29,6 +29,6 @@
 
 #include <pkcs11.h>
 
-#pragma pack(pop, cryptoki)
+#pragma pack(pop)
 
 #endif  // PKCS11_ENV_H

--- a/pkcs11-env.h
+++ b/pkcs11-env.h
@@ -15,7 +15,9 @@
 // limitations under the License.
 
 /* From 2.1 of [PKCS11-base-v2.40]: Cryptoki structures SHALL be packed with 1-byte alignment. */
-#pragma pack(push, 1)
+#if defined(STRICT_P11)
+#  pragma pack(push, 1)
+#endif
 
 /* The following definitions need to be provided to the preprocessor before the PKCS#11 header file can be included */
 #define CK_PTR *
@@ -29,6 +31,8 @@
 
 #include <pkcs11.h>
 
-#pragma pack(pop)
+#if defined(STRICT_P11)
+#  pragma pack(pop)
+#endif
 
 #endif  // PKCS11_ENV_H

--- a/pkcs11-env.h
+++ b/pkcs11-env.h
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* From 2.1 of [PKCS11-base-v2.40]: Cryptoki structures SHALL be packed with 1-byte alignment. */
+#pragma pack(push, cryptoki, 1)
+
 /* The following definitions need to be provided to the preprocessor before the PKCS#11 header file can be included */
 #define CK_PTR *
 #define CK_DEFINE_FUNCTION(returnType, name) returnType name
@@ -23,5 +26,9 @@
 #ifndef NULL_PTR
 #define NULL_PTR 0
 #endif
+
+#include <pkcs11.h>
+
+#pragma pack(pop, cryptoki)
 
 #endif  // PKCS11_ENV_H

--- a/pkcs11test.h
+++ b/pkcs11test.h
@@ -17,10 +17,8 @@
 
 // Master header for all PKCS#11 test code.
 
-// Set up the environment for PKCS#11
+// Set up the environment for PKCS#11 and include the official PKCS#11 header file.
 #include "pkcs11-env.h"
-// Include the official PKCS#11 header file.
-#include <pkcs11.h>
 // Test-wide global variables (specifically g_fns)
 #include "globals.h"
 // Utilities to convert PKCS#11 types to strings.


### PR DESCRIPTION
Section 2.1 of [PKCS11-base-v2.40], as well as comments on pkcs11.h,
define that PKCS#11 structures shall be packed with 1-byte alignment.
    
However, since doing so globally breaks other includes, the packing is
only applied to pkcs11-env.h, refactoring the inclusion of pkcs11.h
into it as well.