### PR TITLE
Allow EC-specific flags for EC mechanisms

### DIFF
--- a/globals.cc
+++ b/globals.cc
@@ -338,6 +338,15 @@ std::set<CK_MECHANISM_TYPE> derive_mechanisms = {
   CKM_EXTRACT_KEY_FROM_KEY,
 };
 
+std::set<CK_MECHANISM_TYPE> elliptic_curve_mechanisms = {
+  CKM_EC_KEY_PAIR_GEN,
+  CKM_ECDSA,
+  CKM_ECDSA_SHA1,
+  CKM_ECDH1_DERIVE,
+  CKM_ECDH1_COFACTOR_DERIVE,
+  CKM_ECMQV_DERIVE,
+};
+
 CK_BBOOL g_ck_false = CK_FALSE;
 CK_BBOOL g_ck_true = CK_TRUE;
 

--- a/globals.h
+++ b/globals.h
@@ -91,6 +91,8 @@ extern std::set<CK_MECHANISM_TYPE> generate_mechanisms;
 extern std::set<CK_MECHANISM_TYPE> wrap_unwrap_mechanisms;
 // PKCS#11 mechanisms for derive.
 extern std::set<CK_MECHANISM_TYPE> derive_mechanisms;
+// PKCS#11 mechanisms for elliptic curve cryptography.
+extern std::set<CK_MECHANISM_TYPE> elliptic_curve_mechanisms;
 
 // Global variables for boolean values.  These are useful in object
 // attribute lists.

--- a/slot.cc
+++ b/slot.cc
@@ -132,6 +132,14 @@ TEST_F(PKCS11Test, EnumerateMechanisms) {
     if (derive_mechanisms.count(mechanism_type)) {
       expected_flags |= CKF_DERIVE;
     }
+    if (elliptic_curve_mechanisms.count(mechanism_type)) {
+      expected_flags |= CKF_EC_F_P;
+      expected_flags |= CKF_EC_F_2M;
+      expected_flags |= CKF_EC_ECPARAMETERS;
+      expected_flags |= CKF_EC_NAMEDCURVE;
+      expected_flags |= CKF_EC_UNCOMPRESS;
+      expected_flags |= CKF_EC_COMPRESS;
+    }
     // Check that the mechanism's flags are a subset of those expected.
     CK_FLAGS extra_flags = mechanism_info.flags;
     extra_flags &= ~(expected_flags);


### PR DESCRIPTION
Section 12.3 of PKCS#11 v2.20 has various additional flags
that can be used to indicate capabilities of EC-specific
mechanisms.  Allow these flag values for EC-related mechanisms.

Fixes #7.