### PR TITLE
Use public objects in public session tests

### DIFF
--- a/cipher.cc
+++ b/cipher.cc
@@ -564,6 +564,7 @@ TEST_F(ReadOnlySessionTest, CreateSecretKeyAttributes) {
   CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
   CK_KEY_TYPE key_type = CKK_DES;
   vector<CK_ATTRIBUTE> attrs = {
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
     {CKA_LABEL, (CK_VOID_PTR)g_label, g_label_len},
     {CKA_ENCRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_DECRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
@@ -612,6 +613,7 @@ TEST_F(ReadOnlySessionTest, SecretKeyTestVectors) {
       CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
       CK_KEY_TYPE key_type = info.keytype;
       vector<CK_ATTRIBUTE> attrs = {
+        {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
         {CKA_LABEL, (CK_VOID_PTR)g_label, g_label_len},
         {CKA_ENCRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
         {CKA_DECRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},

--- a/hmac.cc
+++ b/hmac.cc
@@ -92,6 +92,7 @@ class HmacTest : public ReadOnlySessionTest,
     CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
     CK_KEY_TYPE key_type = CKK_GENERIC_SECRET;
     vector<CK_ATTRIBUTE> attrs = {
+      {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
       {CKA_LABEL, (CK_VOID_PTR)g_label, g_label_len},
       {CKA_SIGN, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
       {CKA_VERIFY, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},

--- a/hmac.cc
+++ b/hmac.cc
@@ -171,6 +171,7 @@ TEST_F(ReadOnlySessionTest, HmacTestVectors) {
       CK_OBJECT_CLASS key_class = CKO_SECRET_KEY;
       CK_KEY_TYPE key_type = CKK_GENERIC_SECRET;
       vector<CK_ATTRIBUTE> attrs = {
+        {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
         {CKA_LABEL, (CK_VOID_PTR)g_label, g_label_len},
         {CKA_SIGN, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
         {CKA_VERIFY, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},

--- a/keypair.cc
+++ b/keypair.cc
@@ -128,12 +128,14 @@ TEST_F(ReadWriteSessionTest, PublicExponent4Bytes) {
   CK_ULONG modulus_bits = 1024;
   CK_BYTE public_exponent_value[] = {0x00, 0x1, 0x0, 0x1}; // 65537=0x00010001
   vector<CK_ATTRIBUTE> public_attrs = {
-    {CKA_ENCRYPT},
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
+    {CKA_ENCRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_MODULUS_BITS, &modulus_bits, sizeof(modulus_bits)},
     {CKA_PUBLIC_EXPONENT, public_exponent_value, sizeof(public_exponent_value)},
   };
   vector<CK_ATTRIBUTE> private_attrs = {
-    {CKA_DECRYPT},
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
+    {CKA_DECRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
   };
   CK_MECHANISM mechanism = {CKM_RSA_PKCS_KEY_PAIR_GEN, NULL_PTR, 0};
   CK_OBJECT_HANDLE public_key = INVALID_OBJECT_HANDLE;
@@ -190,6 +192,7 @@ TEST_F(ReadWriteSessionTest, AsymmetricTokenKeyPair) {
   CK_ATTRIBUTE public_attrs[] = {
     {CKA_ENCRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_TOKEN, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
     {CKA_LABEL, (CK_VOID_PTR)g_label, g_label_len},
     {CKA_MODULUS_BITS, &modulus_bits, sizeof(modulus_bits)},
     {CKA_PUBLIC_EXPONENT, public_exponent_value, sizeof(public_exponent_value)},
@@ -197,6 +200,7 @@ TEST_F(ReadWriteSessionTest, AsymmetricTokenKeyPair) {
   CK_ATTRIBUTE private_attrs[] = {
     {CKA_DECRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_TOKEN, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
     {CKA_LABEL, (CK_VOID_PTR)g_label, g_label_len},
   };
   CK_MECHANISM mechanism = {CKM_RSA_PKCS_KEY_PAIR_GEN, NULL_PTR, 0};
@@ -227,6 +231,7 @@ TEST_F(ReadOnlySessionTest, CreateKeyPairObjects) {
     {CKA_ENCRYPT, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_VERIFY, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_TOKEN, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
     {CKA_CLASS, &public_key_class, sizeof(public_key_class)},
     {CKA_KEY_TYPE, (CK_VOID_PTR)&key_type, sizeof(key_type)},
     {CKA_PUBLIC_EXPONENT, (CK_VOID_PTR)public_exponent.data(), public_exponent.size()},
@@ -246,6 +251,7 @@ TEST_F(ReadOnlySessionTest, CreateKeyPairObjects) {
     {CKA_SENSITIVE, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_EXTRACTABLE, (CK_VOID_PTR)&g_ck_true, sizeof(CK_BBOOL)},
     {CKA_TOKEN, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
+    {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)},
     {CKA_CLASS, &private_key_class, sizeof(private_key_class)},
     {CKA_KEY_TYPE, (CK_VOID_PTR)&key_type, sizeof(key_type)},
     {CKA_PUBLIC_EXPONENT, (CK_VOID_PTR)public_exponent.data(), public_exponent.size()},

--- a/object.cc
+++ b/object.cc
@@ -132,6 +132,7 @@ TEST_F(ReadWriteSessionTest, CreateCopyDestroyObject) {
   CK_ATTRIBUTE attrs[] = {
     {CKA_CLASS, &data_class, sizeof(data_class)},
     {CKA_TOKEN, &g_ck_false, sizeof(g_ck_false)},  // Session object
+    {CKA_PRIVATE, &g_ck_false, sizeof(g_ck_false)},
     {CKA_APPLICATION, app, sizeof(app)},
     {CKA_VALUE, deadbeef, sizeof(deadbeef)},
     {CKA_LABEL, label, 8},
@@ -286,6 +287,7 @@ class DataObjectTest : public ReadWriteSessionTest {
     CK_ATTRIBUTE attrs[] = {
       {CKA_CLASS, &data_class, sizeof(data_class)},
       {CKA_TOKEN, &g_ck_false, sizeof(g_ck_false)},  // Session object
+      {CKA_PRIVATE, &g_ck_false, sizeof(g_ck_false)},
       {CKA_APPLICATION, app, sizeof(app)},
       {CKA_VALUE, deadbeef, sizeof(deadbeef)},
       {CKA_LABEL, label, 5},

--- a/pkcs11test.h
+++ b/pkcs11test.h
@@ -246,6 +246,8 @@ class SecretKey {
       CK_ATTRIBUTE valuelen = {CKA_VALUE_LEN, &len, sizeof(CK_ULONG)};
       attrs_.push_back(valuelen);
     }
+    CK_ATTRIBUTE public_object = {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)};
+    attrs_.push_back(public_object);
     CK_MECHANISM mechanism = {keygen_mechanism, NULL_PTR, 0};
     EXPECT_CKR_OK(g_fns->C_GenerateKey(session_, &mechanism,
                                        attrs_.data(), attrs_.size(),
@@ -279,6 +281,10 @@ class KeyPair {
     CK_BYTE public_exponent_value[] = {0x1, 0x0, 0x1}; // 65537=0x010001
     CK_ATTRIBUTE public_exponent = {CKA_PUBLIC_EXPONENT, public_exponent_value, sizeof(public_exponent_value)};
     public_attrs_.push_back(public_exponent);
+
+    CK_ATTRIBUTE public_object = {CKA_PRIVATE, (CK_VOID_PTR)&g_ck_false, sizeof(CK_BBOOL)};
+    public_attrs_.push_back(public_object);
+    private_attrs_.push_back(public_object);
 
     CK_MECHANISM mechanism = {CKM_RSA_PKCS_KEY_PAIR_GEN, NULL_PTR, 0};
     EXPECT_CKR_OK(g_fns->C_GenerateKeyPair(session_, &mechanism,


### PR DESCRIPTION
Currently tests does not specify `CKA_PRIVATE` attribute when calling `C_CreateObject`, `C_GenerateKey`, `C_GenerateKeyPair`. In that case the default vaules are used which are token-specific.

If a default value happens to be `CKA_PRIVATE=true`, then public session tests (`ReadOnlySessionTest` and `ReadWriteSession`) fail with `CKR_USER_NOT_LOGGED_IN` error.

This patch explicitly sets `CKA_PRIVATE=false` inside public session tests.