### PR TITLE
Fixes #20 skip checking of flags for unknown mechs

### DIFF
--- a/slot.cc
+++ b/slot.cc
@@ -103,6 +103,11 @@ TEST_F(PKCS11Test, EnumerateMechanisms) {
     EXPECT_CKR_OK(g_fns->C_GetMechanismInfo(g_slot_id, mechanism_type, &mechanism_info));
     if (g_verbose) cout << "mechanism[" << ii << "]=" << mechanism_type_name(mechanism_type)
                         << " " << mechanism_info_description(&mechanism_info) << endl;
+
+    if (mechanism_type_name(mechanism_type) == "UNKNOWN") {
+      continue;
+    }
+
     EXPECT_LE(mechanism_info.ulMinKeySize, mechanism_info.ulMaxKeySize);
     // Check the expected functionality is available.
     CK_FLAGS expected_flags = CKF_HW;


### PR DESCRIPTION
This change skips checking of allowed mechanism flags for mechanisms
that are not known to the test suite (such as vendor defined mechs).

It also adds:
  CKM_SHA224_RSA_PKCS_PSS
  CKM_SHA224_HMAC_GENERAL
  CKM_SHA224_HMAC
  CKM_SHA224
  CKM_AES_ECB
  CKM_DES_ECB
  CKM_DES3_ECB

To the known mechs list in globals.cc