### PR TITLE
Use C_Encrypt Instead of C_EncryptUpdate

### DIFF
--- a/cipher.cc
+++ b/cipher.cc
@@ -509,9 +509,9 @@ TEST_P(SecretKeyTest, DecryptFinalErrors1) {
   CK_BYTE ciphertext[1024];
   CK_ULONG ciphertext_len = sizeof(ciphertext);
   ASSERT_CKR_OK(g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
-  ASSERT_CKR_OK(g_fns->C_EncryptUpdate(session_,
-                                       plaintext_.get(), kNumBlocks * info_.blocksize,
-                                       ciphertext, &ciphertext_len));
+  ASSERT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
 
   // Variety of bad arguments to C_DecryptFinal.  Each error terminates the
   // operation and so need re-initialization.
@@ -533,9 +533,9 @@ TEST_P(SecretKeyTest, DecryptFinalErrors2) {
   CK_BYTE ciphertext[1024];
   CK_ULONG ciphertext_len = sizeof(ciphertext);
   ASSERT_CKR_OK(g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
-  ASSERT_CKR_OK(g_fns->C_EncryptUpdate(session_,
-                                       plaintext_.get(), kNumBlocks * info_.blocksize,
-                                       ciphertext, &ciphertext_len));
+  ASSERT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
 
   CK_BYTE plaintext[1024];
   CK_BYTE_PTR output = plaintext;


### PR DESCRIPTION
According to the latest [PKCS#11 Standard](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.pdf);  

> After calling C_EncryptInit, the application can either call C_Encrypt to encrypt data in a single part; or
> call C_EncryptUpdate zero or more times, followed by C_EncryptFinal, to encrypt data in multiple parts.
> **The encryption operation is active until the application uses a call to C_Encrypt or C_EncryptFinal** to
> actually obtain the final piece of ciphertext.

In the implementation on [SoftHSMv2](https://github.com/opendnssec/SoftHSMv2/blob/develop/src/lib/SoftHSM.cpp) `C_EncryptUpdate` call doesn't finish the encryption operation. So `C_EncryptFinal` must be called for a further cryptographic operation.

Instead of this, the `C_Encrypt` method can be used in the **DecryptFinalErrors1 and DecryptFinalErrors2** test case. And this solves the problem.