### PR TITLE
Skip Test If Dual Crypto Operations Totally Not Supported

### DIFF
--- a/dual.cc
+++ b/dual.cc
@@ -42,6 +42,11 @@ class DualSecretKeyTest : public SecretKeyTest {
 }  // namespace
 
 TEST_P(DualSecretKeyTest, DigestEncrypt) {
+  if (!(g_token_flags & CKF_DUAL_CRYPTO_OPERATIONS)) {
+    TEST_SKIPPED("Dual digest+encrypt not supported");
+    return;
+  }
+
   // Start digest and encryption operations
   ASSERT_CKR_OK(g_fns->C_DigestInit(session_, &digest_mechanism_));
   ASSERT_CKR_OK(g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));


### PR DESCRIPTION
According to the latest [PKCS#11 Standard](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.pdf);  

> CKF_DUAL_CRYPTO_OPERATIONS 0x00000200
> True if a single session with the token can perform dual cryptographic operations (see Section 5.12)

If it is false, this indicates that dual crypto operations totally not supported. So we can safely skip the test.  

Otherwise, calling `C_DigestInit` and `C_EncryptInit` functions following each other is implementation-defined and not guaranteed to become successful. This can be understood from the [PKCS#11 Standard](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.pdf);  

> CKR_OPERATION_ACTIVE: **There is already an active operation** (or combination of active
> operations) **which prevents Cryptoki from activating the specified operation.** For example, an active
> object-searching operation would prevent Cryptoki from activating an encryption operation with
> C_EncryptInit. Or, an active digesting operation and an active encryption operation would prevent
> Cryptoki from activating a signature operation. Or, on a token which doesn’t support simultaneous
> dual cryptographic operations in a session (**see the description of the**
> **CKF_DUAL_CRYPTO_OPERATIONS flag in the CK_TOKEN_INFO structure**), an active signature
> operation would prevent Cryptoki from activating an encryption operation.