### PR TITLE
Finish Active Operation Before Starting a New One

### DIFF
--- a/cipher.cc
+++ b/cipher.cc
@@ -255,6 +255,13 @@ TEST_P(SecretKeyTest, EncryptDecryptInitInvalid) {
   EXPECT_CKR(CKR_OPERATION_ACTIVE,
              g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
 
+  // Finish active operation before starting a new one
+  CK_BYTE ciphertext[1024];
+  CK_ULONG ciphertext_len = sizeof(ciphertext);
+  EXPECT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
+
   EXPECT_CKR_OK(g_fns->C_DecryptInit(session_, &mechanism_, key_.handle()));
   EXPECT_CKR(CKR_OPERATION_ACTIVE,
              g_fns->C_DecryptInit(session_, &mechanism_, key_.handle()));


### PR DESCRIPTION
According to the latest [PKCS#11 Standard](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.pdf);  

> After calling C_EncryptInit, the application can either call C_Encrypt to encrypt data in a single part; or
> call C_EncryptUpdate zero or more times, followed by C_EncryptFinal, to encrypt data in multiple parts.
> **The encryption operation is active until the application uses a call to C_Encrypt or C_EncryptFinal** to
> actually obtain the final piece of ciphertext.

In the implementation on [SoftHSMv2](https://github.com/opendnssec/SoftHSMv2/blob/develop/src/lib/SoftHSM.cpp) second `C_EncryptInit` call doesn't finish the **active encryption operation**. So encryption operation should be finished for a further cryptographic operation.