### PR TITLE
Add missing #include for GCC 15

### DIFF
--- a/object.cc
+++ b/object.cc
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include "pkcs11test.h"
 
+#include <iomanip>
 #include <set>
 #include <vector>
 


### PR DESCRIPTION
Fixes:

```
g++ -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/r
edhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialec
t=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer  -Ithird_party/pkcs11  -isystem /usr/include/gtest -g -std=c++14 -Wall   -c -o object.o object.cc
object.cc: In function ‘void pkcs11::test::{anonymous}::EnumerateObjects(CK_SESSION_HANDLE)’:
object.cc:70:44: error: ‘setw’ was not declared in this scope
   70 |     if (g_verbose) cout << "  object x" << setw(8) << setfill('0') << hex << (unsigned int)object
      |                                            ^~~~
object.cc:28:1: note: ‘std::setw’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
   27 | #include "pkcs11test.h"
  +++ |+#include <iomanip>
   28 |
object.cc:70:55: error: ‘setfill’ was not declared in this scope
   70 |     if (g_verbose) cout << "  object x" << setw(8) << setfill('0') << hex << (unsigned int)object
      |                                                       ^~~~~~~
object.cc:70:55: note: ‘std::setfill’ is defined in header ‘<iomanip>’; this is probably fixable by adding ‘#include <iomanip>’
```